### PR TITLE
cockpit: link against libfts on libc-musl build

### DIFF
--- a/meta-webserver/recipes-webadmin/cockpit/cockpit_218.bb
+++ b/meta-webserver/recipes-webadmin/cockpit/cockpit_218.bb
@@ -1,0 +1,177 @@
+SUMMARY = "Admin interface for Linux machines"
+DESCRIPTION = "Cockpit makes it easy to administer your GNU/Linux servers via a web browser"
+
+LICENSE = "LGPLv2.1"
+LIC_FILES_CHKSUM = "file://COPYING;md5=4fbd65380cdd255951079008b364516c"
+
+SRC_URI += " \
+    https://github.com/cockpit-project/cockpit/releases/download/${PV}/cockpit-${PV}.tar.xz \
+    file://0001-remove-tests-dep-on-gobject-intro.patch \
+    file://0002-fix-makefile-use-copy-rule-for-unmodified-files.patch \
+    file://cockpit.pam \
+    "
+SRC_URI[md5sum] = "e69b0b8a75a5d55ddfd9817d857c71af"
+SRC_URI[sha256sum] = "5f242cefccd7f1120c9e0310581aa51dbe941d9c4a6d8375c45057dcbb6f2fbb"
+
+inherit gettext pkgconfig autotools systemd distro_features_check
+
+DEPENDS += "glib-2.0-native intltool-native gnutls"
+DEPENDS += "virtual/gettext json-glib krb5 libpam"
+
+RDEPENDS_${PN} += "glib-networking"
+
+REQUIRED_DISTRO_FEATURES = "systemd pam"
+
+COCKPIT_USER_GROUP ?= "root"
+COCKPIT_WS_USER_GROUP ?= "${COCKPIT_USER_GROUP}"
+
+EXTRA_AUTORECONF = "-I tools"
+EXTRA_OECONF = " \
+    --with-cockpit-user=${COCKPIT_USER_GROUP} \
+    --with-cockpit-group=${COCKPIT_USER_GROUP} \
+    --with-cockpit-ws-instance-user=${COCKPIT_WS_USER_GROUP} \
+    --with-cockpit-ws-instance-group=${COCKPIT_WS_USER_GROUP} \
+    --disable-doc \
+    --with-systemdunitdir=${systemd_system_unitdir} \
+"
+
+PACKAGECONFIG[pcp] = "--enable-pcp,--disable-pcp,pcp"
+PACKAGECONFIG[dashboard] = "--enable-ssh,--disable-ssh,libssh"
+
+PACKAGES =+ " \
+    ${PN}-pcp \
+    ${PN}-realmd \
+    ${PN}-tuned \
+    ${PN}-shell \
+    ${PN}-systemd \
+    ${PN}-users \
+    ${PN}-kdump \
+    ${PN}-sosreport \
+    ${PN}-storaged \
+    ${PN}-networkmanager \
+    ${PN}-machines \
+    ${PN}-selinux \
+    ${PN}-playground \
+    ${PN}-docker \
+    ${PN}-dashboard \
+    ${PN}-bridge \
+    ${PN}-ws \
+    ${PN}-desktop \
+"
+SYSTEMD_PACKAGES = "${PN}-ws"
+
+FILES_${PN}-pcp = " \
+    ${libexecdir}/cockpit-pcp \
+    ${datadir}/cockpit/pcp \
+    ${localstatedir}/lib/pcp/config/pmlogconf/tools/cockpit \
+"
+FILES_${PN}-realmd = "${datadir}/cockpit/realmd"
+FILES_${PN}-tuned = "${datadir}/cockpit/tuned"
+FILES_${PN}-shell = "${datadir}/cockpit/shell"
+FILES_${PN}-systemd = "${datadir}/cockpit/systemd"
+FILES_${PN}-users = "${datadir}/cockpit/users"
+FILES_${PN}-kdump = " \
+    ${datadir}/cockpit/kdump \
+    ${datadir}/metainfo/org.cockpit-project.cockpit-kdump.metainfo.xml \
+"
+FILES_${PN}-sosreport = " \
+    ${datadir}/cockpit/sosreport \
+    ${datadir}/metainfo/org.cockpit-project.cockpit-sosreport.metainfo.xml \
+    ${datadir}/pixmaps/cockpit-sosreport.png \
+"
+FILES_${PN}-storaged = " \
+    ${datadir}/cockpit/storaged \
+    ${datadir}/metainfo/org.cockpit-project.cockpit-storaged.metainfo.xml \
+"
+FILES_${PN}-networkmanager = "${datadir}/cockpit/networkmanager"
+RDEPENDS_${PN}-networkmanager = "networkmanager"
+
+FILES_${PN}-machines = " \
+    ${datadir}/cockpit/machines \
+    ${datadir}/metainfo/org.cockpit-project.cockpit-machines.metainfo.xml \
+"
+FILES_${PN}-selinux = " \
+    ${datadir}/cockpit/selinux \
+    ${datadir}/metainfo/org.cockpit-project.cockpit-selinux.metainfo.xml \
+"
+FILES_${PN}-playground = "${datadir}/cockpit/playground"
+FILES_${PN}-docker = " \
+    ${datadir}/cockpit/docker \
+    ${datadir}/metainfo/org.cockpit-project.cockpit-docker.metainfo.xml \
+"
+FILES_${PN}-dashboard = "${datadir}/cockpit/dashboard"
+ALLOW_EMPTY_${PN}-dashboard = "1"
+
+FILES_${PN}-bridge = " \
+    ${bindir}/cockpit-bridge \
+    ${libexec}/cockpit-askpass \
+"
+RDEPENDS_${PN}-bridge = ""
+
+FILES_${PN}-desktop = "${libexecdir}/cockpit-desktop"
+RDEPENDS_${PN}-desktop += "bash"
+
+FILES_${PN}-ws = " \
+    ${sysconfdir}/cockpit/ws-certs.d \
+    ${sysconfdir}/pam.d/cockpit \
+    ${sysconfdir}/issue.d/cockpit.issue \
+    ${sysconfdir}/motd.d/cockpit \
+    ${datadir}/cockpit/motd/update-motd \
+    ${datadir}/cockpit/motd/inactive.motd \
+    ${systemd_system_unitdir}/cockpit.service \
+    ${systemd_system_unitdir}/cockpit-motd.service \
+    ${systemd_system_unitdir}/cockpit.socket \
+    ${systemd_system_unitdir}/cockpit-wsinstance-http.socket \
+    ${systemd_system_unitdir}/cockpit-wsinstance-http.service \
+    ${systemd_system_unitdir}/cockpit-wsinstance-http-redirect.socket \
+    ${systemd_system_unitdir}/cockpit-wsinstance-http-redirect.service \
+    ${systemd_system_unitdir}/cockpit-wsinstance-https-factory.socket \
+    ${systemd_system_unitdir}/cockpit-wsinstance-https-factory@.service \
+    ${systemd_system_unitdir}/cockpit-wsinstance-https@.socket \
+    ${systemd_system_unitdir}/cockpit-wsinstance-https@.service \
+    ${systemd_system_unitdir}/system-cockpithttps.slice \
+    ${libdir}/tmpfiles.d/cockpit-tempfiles.conf \
+    ${sbindir}/remotectl \
+    ${libdir}/security/pam_ssh_add.so \
+    ${libdir}/security/pam_cockpit_cert.so \
+    ${libexecdir}/cockpit-ws \
+    ${libexecdir}/cockpit-wsinstance-factory \
+    ${libexecdir}/cockpit-tls \
+    ${libexecdir}/cockpit-session \
+    ${localstatedir}/lib/cockpit \
+    ${datadir}/cockpit/static \
+    ${datadir}/cockpit/branding \
+"
+CONFFILES_${PN}-ws += " \
+    ${sysconfdir}/issue.d/cockpit.issue \
+    ${sysconfdir}/motd.d/cockpit \
+"
+RDEPENDS_${PN}-ws += "openssl-bin"
+SYSTEMD_SERVICE_${PN}-ws = "cockpit.socket"
+
+FILES_${PN} += " \
+    ${datadir}/cockpit/base1 \
+    ${sysconfdir}/cockpit/machines.d \
+    ${datadir}/polkit-1/actions/org.cockpit-project.cockpit-bridge.policy \
+    ${datadir}/cockpit/ssh \
+    ${libexecdir}/cockpit-ssh \
+    ${datadir}/cockpit \
+    ${datadir}/metainfo/cockpit.appdata.xml \
+    ${datadir}/pixmaps/cockpit.png \
+"
+RDEPENDS_${PN} += "${PN}-bridge"
+
+do_install_append() {
+    pkgdatadir=${datadir}/cockpit
+
+    # avoid host contamination
+    find ${D}${datadir}/cockpit -name manifest.json -exec chown root:root {} \;
+
+    chmod 4750 ${D}${libexecdir}/cockpit-session
+
+    install -d "${D}${sysconfdir}/pam.d"
+    install -p -m 0644 ${WORKDIR}/cockpit.pam ${D}${sysconfdir}/pam.d/cockpit
+
+    # provided by firewalld
+    rm -rf ${D}${libdir}/firewalld
+}

--- a/meta-webserver/recipes-webadmin/cockpit/cockpit_218.bb
+++ b/meta-webserver/recipes-webadmin/cockpit/cockpit_218.bb
@@ -17,6 +17,7 @@ inherit gettext pkgconfig autotools systemd distro_features_check
 
 DEPENDS += "glib-2.0-native intltool-native gnutls"
 DEPENDS += "virtual/gettext json-glib krb5 libpam"
+DEPENDS_append_libc-musl = " fts"
 
 RDEPENDS_${PN} += "glib-networking"
 
@@ -34,6 +35,7 @@ EXTRA_OECONF = " \
     --disable-doc \
     --with-systemdunitdir=${systemd_system_unitdir} \
 "
+EXTRA_OECONF_append_libc-musl = " LIBS=-lfts"
 
 PACKAGECONFIG[pcp] = "--enable-pcp,--disable-pcp,pcp"
 PACKAGECONFIG[dashboard] = "--enable-ssh,--disable-ssh,libssh"

--- a/meta-webserver/recipes-webadmin/cockpit/files/0001-remove-tests-dep-on-gobject-intro.patch
+++ b/meta-webserver/recipes-webadmin/cockpit/files/0001-remove-tests-dep-on-gobject-intro.patch
@@ -1,0 +1,77 @@
+From 788aace494f79e8201b18ebcdf1592b5030c5295 Mon Sep 17 00:00:00 2001
+From: Adrian Freihofer <adrian.freihofer@siemens.com>
+Date: Wed, 4 Dec 2019 17:23:46 +0100
+Subject: [PATCH] remove tests dep on gobject-intro
+
+---
+ src/ws/Makefile-ws.am | 54 ---------------------------------------------------
+ 1 file changed, 54 deletions(-)
+
+diff --git a/src/ws/Makefile-ws.am b/src/ws/Makefile-ws.am
+index 009130941..34e13d7fe 100644
+--- a/src/ws/Makefile-ws.am
++++ b/src/ws/Makefile-ws.am
+@@ -246,60 +246,6 @@ EXTRA_DIST += \
+ 
+ # ----------------------------------------------------------------------------------------------------
+ 
+-noinst_PROGRAMS += test-server
+-check_PROGRAMS += test-server
+-
+-GDBUS_CODEGEN_XML = $(srcdir)/src/ws/com.redhat.Cockpit.DBusTests.xml
+-
+-GDBUS_CODEGEN_GENERATED = \
+-	src/ws/mock-dbus-tests.h \
+-	src/ws/mock-dbus-tests.c \
+-	$(NULL)
+-
+-# FIXME: --header/--body and --output are only available from GLib 2.56.
+-# just use --generate-c-code and a bit of dependency ugliness for now
+-GDBUS_CODEGEN_INVOCATION = \
+-	$(AM_V_GEN) gdbus-codegen \
+-	--interface-prefix com.redhat.Cockpit.DBusTests \
+-	--c-namespace Test \
+-	--c-generate-object-manager \
+-	--generate-c-code src/ws/mock-dbus-tests \
+-	$(GDBUS_CODEGEN_XML)
+-
+-BUILT_SOURCES += $(GDBUS_CODEGEN_GENERATED)
+-CLEANFILES += $(GDBUS_CODEGEN_GENERATED)
+-EXTRA_DIST += $(GDBUS_CODEGEN_XML)
+-
+-src/ws/mock-dbus-tests.h: $(GDBUS_CODEGEN_XML)
+-	$(GDBUS_CODEGEN_INVOCATION)
+-
+-src/ws/mock-dbus-tests.c: $(GDBUS_CODEGEN_XML) src/ws/mock-dbus-tests.h
+-	$(GDBUS_CODEGEN_INVOCATION)
+-
+-test_server_SOURCES = \
+-	src/ws/mock-service.c \
+-	src/ws/mock-service.h \
+-	src/ws/test-server.c \
+-	$(NULL)
+-
+-nodist_test_server_SOURCES = \
+-	$(GDBUS_CODEGEN_GENERATED) \
+-	$(NULL)
+-
+-test_server_CFLAGS = 					\
+-	-I$(builddir)/src/ws \
+-	-I$(top_srcdir)/src/ws \
+-	-DG_LOG_DOMAIN=\"test-server\"			\
+-	$(GIO_CFLAGS)					\
+-	$(COCKPIT_WS_CFLAGS) \
+-	$(NULL)
+-
+-test_server_LDADD = 					\
+-	$(libcockpit_ws_LIBS) \
+-	$(GIO_LIBS)					\
+-	-lpam 						\
+-	$(NULL)
+-
+ WS_CHECKS = \
+ 	test-base64 \
+ 	test-creds \
+-- 
+2.11.0
+

--- a/meta-webserver/recipes-webadmin/cockpit/files/0002-fix-makefile-use-copy-rule-for-unmodified-files.patch
+++ b/meta-webserver/recipes-webadmin/cockpit/files/0002-fix-makefile-use-copy-rule-for-unmodified-files.patch
@@ -1,0 +1,47 @@
+From 1edf0756bf4fd002f5b60cf2b86d4b97a00aff20 Mon Sep 17 00:00:00 2001
+From: Michael Haener <michael.haener@siemens.com>
+Date: Wed, 25 Mar 2020 08:32:07 +0100
+Subject: [PATCH] fix(makefile): use copy rule for unmodified files
+
+---
+ pkg/Makefile.am | 27 +++++++++++++++++++++++++++
+ 1 file changed, 27 insertions(+)
+
+diff --git a/pkg/Makefile.am b/pkg/Makefile.am
+index 192b785..03b9787 100644
+--- a/pkg/Makefile.am
++++ b/pkg/Makefile.am
+@@ -13,6 +13,33 @@ playground_DATA = \
+ dist/playground/extra.de.po: pkg/playground/extra.de.po
+ 	$(COPY_RULE)
+ 
++dist/playground/hammer.gif: pkg/playground/hammer.gif
++	$(COPY_RULE)
++
++dist/sosreport/sosreport.png: pkg/sosreport/sosreport.png
++	$(COPY_RULE)
++
++dist/apps/default.png: pkg/apps/default.png
++	$(COPY_RULE)
++
++dist/storaged/images/storage-array.png: pkg/storaged/images/storage-array.png
++	$(COPY_RULE)
++
++dist/storaged/images/storage-disk.png: pkg/storaged/images/storage-disk.png
++	$(COPY_RULE)
++
++dist/shell/images/server-error.png: pkg/shell/images/server-error.png
++	$(COPY_RULE)
++
++dist/shell/images/server-large.png: pkg/shell/images/server-large.png
++	$(COPY_RULE)
++
++dist/shell/images/server-small.png: pkg/shell/images/server-small.png
++	$(COPY_RULE)
++
++dist/shell/index.html: pkg/shell/index.html
++	$(COPY_RULE)
++
+ metainfodir = ${datarootdir}/metainfo
+ metainfo_DATA = pkg/sosreport/org.cockpit-project.cockpit-sosreport.metainfo.xml \
+ 		pkg/kdump/org.cockpit-project.cockpit-kdump.metainfo.xml \

--- a/meta-webserver/recipes-webadmin/cockpit/files/cockpit.pam
+++ b/meta-webserver/recipes-webadmin/cockpit/files/cockpit.pam
@@ -1,0 +1,8 @@
+#%PAM-1.0
+auth        required      pam_unix.so     nullok
+
+account     required      pam_unix.so
+
+-session    optional      pam_systemd.so
+session     required      pam_unix.so
+session     optional      pam_keyinit.so force revoke


### PR DESCRIPTION
Musl-libc does not implement file traversal functions from fts.h.
Add fts depends on musl-libc as oe-core provides a recipe for the
fts library.

Signed-off-by: Emmanuel Roullit <emmanuel.roullit@gmail.com>